### PR TITLE
Fix for the examples url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ sendpulse.init(API_USER_ID,API_SECRET,TOKEN_STORAGE,function() {
 });
 ```
 
-You can get full list of API library methods in [https://github.com/sendpulse/sendpulse-rest-api-node.js/blob/master/example.js](example)
+You can get full list of API library methods in [example](https://github.com/sendpulse/sendpulse-rest-api-node.js/blob/master/example.js)


### PR DESCRIPTION
The url itself and the anchor text was mixed, so instead of clicking on https://github.com/sendpulse/sendpulse-rest-api-node.js/blob/master/example.js click goes to "example".