### PR TITLE
support CloudFlare workers environment

### DIFF
--- a/api/fs-provider.js
+++ b/api/fs-provider.js
@@ -1,38 +1,39 @@
-var fs = require('node:fs');
+var fs = require("node:fs");
 /**
  * Create directory
  *
  * @param directory
  */
 function mkdirSyncRecursive(directory) {
-    var path = directory.replace(/\/$/, '').split('/');
-    for (var i = 1; i <= path.length; i++) {
-        var segment = path.slice(0, i).join('/');
-        segment.length > 0 && !fs.existsSync(segment) ? fs.mkdirSync(segment) : null;
-    }
-};
-
-class fsProvider {
-    constructor(path) {
-
-        if (!fs.existsSync(path)) {
-            mkdirSyncRecursive(path);
-        }
-        if (path.substr(-1) !== '/') {
-            path += '/';
-        }
-        this.path = path;
-    }
-    getToken(hashName) {
-        if (fs.existsSync(this.path + hashName)) {
-            return fs.readFileSync(this.path + hashName, {encoding: 'utf8'});
-        } else {
-            return "";
-        }
-    }
-    setToken(hashName, token) {
-        fs.writeFileSync(this.path + hashName, token);
-    }
+  var path = directory.replace(/\/$/, "").split("/");
+  for (var i = 1; i <= path.length; i++) {
+    var segment = path.slice(0, i).join("/");
+    segment.length > 0 && !fs.existsSync(segment)
+      ? fs.mkdirSync(segment)
+      : null;
+  }
 }
 
-module.exports = fsProvider;
+class fsProvider {
+  constructor(path) {
+    if (!fs.existsSync(path)) {
+      mkdirSyncRecursive(path);
+    }
+    if (path.substr(-1) !== "/") {
+      path += "/";
+    }
+    this.path = path;
+  }
+  getToken(hashName) {
+    if (fs.existsSync(this.path + hashName)) {
+      return fs.readFileSync(this.path + hashName, { encoding: "utf8" });
+    } else {
+      return "";
+    }
+  }
+  setToken(hashName, token) {
+    fs.writeFileSync(this.path + hashName, token);
+  }
+}
+
+exports.fsProvider = fsProvider;

--- a/api/fs-provider.js
+++ b/api/fs-provider.js
@@ -1,0 +1,38 @@
+var fs = require('fs');
+/**
+ * Create directory
+ *
+ * @param directory
+ */
+function mkdirSyncRecursive(directory) {
+    var path = directory.replace(/\/$/, '').split('/');
+    for (var i = 1; i <= path.length; i++) {
+        var segment = path.slice(0, i).join('/');
+        segment.length > 0 && !fs.existsSync(segment) ? fs.mkdirSync(segment) : null;
+    }
+};
+
+class fsProvider {
+    constructor(path) {
+
+        if (!fs.existsSync(path)) {
+            mkdirSyncRecursive(path);
+        }
+        if (path.substr(-1) !== '/') {
+            path += '/';
+        }
+        this.path = path;
+    }
+    getToken(hashName) {
+        if (fs.existsSync(this.path + hashName)) {
+            return fs.readFileSync(this.path + hashName, {encoding: 'utf8'});
+        } else {
+            return "";
+        }
+    }
+    setToken(hashName, token) {
+        fs.writeFileSync(this.path + hashName, token);
+    }
+}
+
+module.exports = fsProvider;

--- a/api/fs-provider.js
+++ b/api/fs-provider.js
@@ -1,4 +1,4 @@
-var fs = require('fs');
+var fs = require('node:fs');
 /**
  * Create directory
  *

--- a/api/memory-provider.js
+++ b/api/memory-provider.js
@@ -1,14 +1,13 @@
-
 class memoryProvider {
-    constructor() {
-     this.store = {};
-    }
-    getToken(hashName) {
-        return this.store[hashName] || "";
-    }
-    setToken(hashName, token) {
-        return this.store[hashName] = token;
-    }
+  constructor() {
+    this.store = {};
+  }
+  getToken(hashName) {
+    return this.store[hashName] || "";
+  }
+  setToken(hashName, token) {
+    return (this.store[hashName] = token);
+  }
 }
 
-module.exports = memoryProvider;
+exports.memoryProvider = memoryProvider;

--- a/api/memory-provider.js
+++ b/api/memory-provider.js
@@ -1,0 +1,14 @@
+
+class memoryProvider {
+    constructor() {
+     this.store = {};
+    }
+    getToken(hashName) {
+        return this.store[hashName] || "";
+    }
+    setToken(hashName, token) {
+        return this.store[hashName] = token;
+    }
+}
+
+module.exports = memoryProvider;

--- a/api/sendpulse.js
+++ b/api/sendpulse.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-var https = require('https');
-var crypto = require('crypto');
+var https = require('node:https');
+var crypto = require('node:crypto');
 
 var API_URL = 'api.sendpulse.com';
 var API_USER_ID = '';

--- a/example.js
+++ b/example.js
@@ -5,7 +5,9 @@
  * https://sendpulse.com/api
  */
 
-var sendpulse = require("sendpulse-api");
+var sendpulse = require("./api/sendpulse");
+// var memoryProvider = require("./api/memory-provider");
+var fsProvider = require("./api/fs-provider");
 
 /*
  * https://login.sendpulse.com/settings/#api
@@ -14,9 +16,10 @@ var sendpulse = require("sendpulse-api");
 var API_USER_ID="USER_ID";
 var API_SECRET="USER_SECRET";
 
-var TOKEN_STORAGE="/tmp/";
+var provider = new fsProvider("./tmp/");
+// var provider = new memoryProvider();
 
-sendpulse.init(API_USER_ID, API_SECRET, TOKEN_STORAGE, function(token) {
+sendpulse.init(API_USER_ID, API_SECRET, provider, function(token) {
     if (token && token.is_error) {
         // error handling
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sendpulse-api",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A simple SendPulse REST client library and example for Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The version in that branch is successfully working at Cloudflare workers environment. We have working within for some time in production, but later we have shifted from sendpulse to customer.io, that's why will not continue support of fork. If somebody else needs to use in edge environments - it's a good starting point. 
This branch includes changes from https://github.com/sendpulse/sendpulse-rest-api-node.js/pull/48 to store tokens in memory.
Also `node:https` removed and substituted within fetch.